### PR TITLE
[cli] manage config file at `~/.colossalai-platform`

### DIFF
--- a/colossalai_platform/cli/__init__.py
+++ b/colossalai_platform/cli/__init__.py
@@ -1,1 +1,3 @@
 from .cli import cli
+
+__all__ = ['cli']

--- a/colossalai_platform/cli/cli.py
+++ b/colossalai_platform/cli/cli.py
@@ -1,17 +1,15 @@
 import click
 
 from colossalai_platform.cli.aliased_group import (CONTEXT_SETTINGS, AliasedGroup)
+from colossalai_platform.cli.context import BaseCommandContext
 
 from .commands import project, dataset, login
-from .config import Config
-
-__all__ = ['cli']
 
 
 @click.command(cls=AliasedGroup, context_settings=CONTEXT_SETTINGS)
 @click.pass_context
-def cli(ctx: click.Context,):
-    ctx.obj = Config()
+def cli(ctx: click.Context):
+    ctx.obj = BaseCommandContext()
 
 
 # add command group

--- a/colossalai_platform/cli/cli.py
+++ b/colossalai_platform/cli/cli.py
@@ -2,15 +2,19 @@ import click
 
 from colossalai_platform.cli.aliased_group import (CONTEXT_SETTINGS, AliasedGroup)
 
-from .commands import project
+from .commands import project, dataset, login
+from .config import Config
 
 __all__ = ['cli']
 
 
 @click.command(cls=AliasedGroup, context_settings=CONTEXT_SETTINGS)
-def cli():
-    pass
+@click.pass_context
+def cli(ctx: click.Context,):
+    ctx.obj = Config()
 
 
 # add command group
+cli.add_command(login)
 cli.add_command(project)
+cli.add_command(dataset)

--- a/colossalai_platform/cli/commands/__init__.py
+++ b/colossalai_platform/cli/commands/__init__.py
@@ -1,1 +1,3 @@
 from .project import project
+from .dataset import dataset
+from .login import login

--- a/colossalai_platform/cli/commands/dataset.py
+++ b/colossalai_platform/cli/commands/dataset.py
@@ -1,0 +1,12 @@
+import os
+import shutil
+
+import click
+
+from colossalai_platform.cli.aliased_group import (CONTEXT_SETTINGS, AliasedGroup)
+
+
+@click.command(cls=AliasedGroup, context_settings=CONTEXT_SETTINGS, help="Manage your datasets")
+def dataset():
+    """TODO(ofey404): build this after login feature"""
+    pass

--- a/colossalai_platform/cli/commands/login.py
+++ b/colossalai_platform/cli/commands/login.py
@@ -5,9 +5,36 @@ import requests
 import click
 
 from colossalai_platform.cli.aliased_group import (CONTEXT_SETTINGS, AliasedGroup)
+from colossalai_platform.cli.context import BaseCommandContext
 
 
-@click.command(cls=AliasedGroup, context_settings=CONTEXT_SETTINGS, help="Login to the platform")
-@click.argument('username', required=1, type=str)
-def login(username):
-    pass
+@click.command(context_settings=CONTEXT_SETTINGS, help="Login to the platform")
+@click.option(
+    '--dont-save-credential',
+    is_flag=True,
+    help='Do not save username and password to local config file',
+)
+@click.pass_context
+def login(ctx: click.Context, dont_save_credential: bool):
+    # TODO(ofey404): In first version we build interactive login,
+    #                and save token to local dir.
+
+    base_ctx = ctx.find_object(BaseCommandContext)
+    assert base_ctx
+
+    print(f"""## Login to the platform.
+
+By default the username and password will be saved to {str(base_ctx.config_path())},
+use --dont-save-credential if you don't want this behavior.
+""")
+    username = click.prompt("Username")
+    password = click.prompt("Password (Hide input)", hide_input=True)
+
+    # TODO(ofey404): do the request
+
+    if dont_save_credential:
+        return
+
+    base_ctx.config.username = username
+    base_ctx.config.password = password
+    base_ctx.dump_to_dir()

--- a/colossalai_platform/cli/commands/login.py
+++ b/colossalai_platform/cli/commands/login.py
@@ -24,7 +24,7 @@ def login(ctx: click.Context, dont_save_credential: bool):
 
     print(f"""## Login to the platform.
 
-By default the username and password will be saved to {str(base_ctx.config_path())},
+By default the username and password will be saved to {str(base_ctx.config_path())}
 use --dont-save-credential if you don't want this behavior.
 """)
     username = click.prompt("Username")

--- a/colossalai_platform/cli/commands/login.py
+++ b/colossalai_platform/cli/commands/login.py
@@ -1,0 +1,13 @@
+import os
+import shutil
+import requests
+
+import click
+
+from colossalai_platform.cli.aliased_group import (CONTEXT_SETTINGS, AliasedGroup)
+
+
+@click.command(cls=AliasedGroup, context_settings=CONTEXT_SETTINGS, help="Login to the platform")
+@click.argument('username', required=1, type=str)
+def login(username):
+    pass

--- a/colossalai_platform/cli/config.py
+++ b/colossalai_platform/cli/config.py
@@ -1,0 +1,39 @@
+import yaml
+from pydantic import BaseModel
+from pathlib import Path
+
+# The directory and the config file
+CONFIG_DIR = Path.home() / ".cloud-platform"
+CONFIG_FILE = CONFIG_DIR / "config.yaml"
+TOKEN_FILE = CONFIG_DIR / "config.yaml"
+
+
+# Your config class
+class Config(BaseModel):
+    field1: str
+    field2: int
+    # Define your fields here
+
+
+def load_or_create_config() -> Config:
+    """Load the config if it exists at the default place,
+    otherwise create it.
+    """
+    try:
+        return _load_config()
+    except FileNotFoundError:
+        _init_config()
+        return _load_config()
+
+
+def _load_config() -> Config:
+    with open(CONFIG_FILE, 'r') as f:
+        config_data = yaml.safe_load(f)
+        config = Config(**config_data)
+        return config
+
+
+def _init_config():
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    with open(CONFIG_FILE, 'w') as f:
+        yaml.dump(Config().dict(), f)

--- a/colossalai_platform/cli/config.py
+++ b/colossalai_platform/cli/config.py
@@ -1,39 +1,6 @@
-import yaml
 from pydantic import BaseModel
-from pathlib import Path
-
-# The directory and the config file
-CONFIG_DIR = Path.home() / ".cloud-platform"
-CONFIG_FILE = CONFIG_DIR / "config.yaml"
-TOKEN_FILE = CONFIG_DIR / "config.yaml"
 
 
-# Your config class
 class Config(BaseModel):
-    field1: str
-    field2: int
-    # Define your fields here
-
-
-def load_or_create_config() -> Config:
-    """Load the config if it exists at the default place,
-    otherwise create it.
-    """
-    try:
-        return _load_config()
-    except FileNotFoundError:
-        _init_config()
-        return _load_config()
-
-
-def _load_config() -> Config:
-    with open(CONFIG_FILE, 'r') as f:
-        config_data = yaml.safe_load(f)
-        config = Config(**config_data)
-        return config
-
-
-def _init_config():
-    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
-    with open(CONFIG_FILE, 'w') as f:
-        yaml.dump(Config().dict(), f)
+    username: str = ""
+    password: str = ""

--- a/colossalai_platform/cli/context.py
+++ b/colossalai_platform/cli/context.py
@@ -1,0 +1,51 @@
+import json
+from pathlib import Path
+
+import yaml
+from pydantic import BaseModel
+
+from colossalai_platform.cli.config import Config
+
+
+class BaseCommandContext(BaseModel):
+    dir: Path = Path.home() / ".cloud-platform"
+    config: Config = Config()
+    token: str = ""
+
+    def __init__(self, **kwargs):
+        # set up default value
+        super().__init__(**kwargs)
+
+        if self.config_path().is_file():
+            self._load_config()
+        else:
+            # TODO(ofey404): more formal logging
+            print(f"## Config doesn't exist on {self.config_path()}, writing default to it")
+            self.dump_to_dir()
+
+        if self._token_path().is_file():
+            with open(self._token_path(), 'r') as f:
+                self.token = f.read()
+
+    def _load_config(self):
+        with open(self.config_path(), 'r') as f:
+            config_dict = yaml.safe_load(f)
+            # update with new data
+            self.config.model_validate(config_dict)
+
+    def dump_to_dir(self):
+        self.dir.mkdir(parents=True, exist_ok=True)
+
+        with open(self.config_path(), 'w') as f:
+            config_dict = self.config.model_dump()
+            yaml.dump(
+                config_dict,
+                f,
+                sort_keys=False,    # Convert the model to a JSON string using the original field order
+            )
+
+    def config_path(self) -> Path:
+        return self.dir / "config.yaml"
+
+    def _token_path(self) -> Path:
+        return self.dir / "token.yaml"

--- a/colossalai_platform/cli/context.py
+++ b/colossalai_platform/cli/context.py
@@ -8,7 +8,7 @@ from colossalai_platform.cli.config import Config
 
 
 class BaseCommandContext(BaseModel):
-    dir: Path = Path.home() / ".cloud-platform"
+    dir: Path = Path.home() / ".colossalai-platform"
     config: Config = Config()
     token: str = ""
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,4 @@
 click
+requests
+pydantic
+pyyaml


### PR DESCRIPTION
This PR handles:

1. Load from/save to a default config file directory.
2. The pattern to use them in the nested CLI.

```
$ cap login
## Config doesn't exist on /home/ofey/.colossalai-platform/config.yaml, writing default to it
## Login to the platform.

By default the username and password will be saved to /home/ofey/.colossalai-platform/config.yaml
use --dont-save-credential if you don't want this behavior.

Username: aaa
Password (Hide input):

$ cat /home/ofey/.colossalai-platform/config.yaml
username: aaa
password: bbb

```