### PR TITLE
[cli] new command `cap dataset upload-dir`

### DIFF
--- a/colossalai_platform/cli/api/__init__.py
+++ b/colossalai_platform/cli/api/__init__.py
@@ -1,3 +1,8 @@
-from .api import ColossalPlatformApi
+from .api import ColossalPlatformApi, StorageType, ApiError, LoginRequiredError
 
-__all__ = [ColossalPlatformApi]
+__all__ = [
+    ColossalPlatformApi,
+    StorageType,
+    ApiError,
+    LoginRequiredError,
+]

--- a/colossalai_platform/cli/api/api.py
+++ b/colossalai_platform/cli/api/api.py
@@ -1,40 +1,127 @@
 import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, IO
 import requests
-from pydantic import BaseModel
+import enum
 
 from colossalai_platform.cli.config import Config
 
+LOGGER = logging.getLogger(__name__)
 
-class LoginError(Exception):
+
+class ApiError(Exception):
     pass
 
 
-class ColossalPlatformApi(BaseModel):
+class LoginRequiredError(Exception):
+
+    def __init__(self, message="Login required"):
+        super().__init__(message)
+
+
+class StorageType(enum.Enum):
+    DATASET = "dataset"
+    PROJECT = "project"
+
+
+@dataclass
+class ColossalPlatformApi:
     config: Config
     token: str = ""
+    session: requests.Session = requests.Session()
 
     def login(self):
-        url = "https://luchentech.com//api/user/login"
+        # TODO: a better URL construction method,
+        #       with pydantic.HttpUrl
+        url = str(self.config.api_server) + "/api/user/login"
 
         if self.config.username == "" or self.config.password == "":
-            raise LoginError("Username or password is empty, please call `cap configure` first")
+            raise ApiError("Username or password is empty, please call `cap configure` first")
 
+        headers = {'Content-Type': 'application/json'}
         payload = json.dumps({
             "username": self.config.username,
             "password": self.config.password,
         })
 
-        headers = {'Content-Type': 'application/json'}
-
-        response = requests.request(
+        response = self.session.request(
             "POST",
             url,
             headers=headers,
             data=payload,
-            verify=False,    # FIXME(ofey404): remove this
         )
 
         if response.status_code == 200:
             self.token = response.json()['accessToken']
         else:
-            raise LoginError(f"Login failed with status code {response.status_code}, body: {response.text}")
+            raise ApiError(f"Login failed with status code {response.status_code}, body: {response.text}")
+
+    def upload(
+        self,
+        storage_type: StorageType,
+        storage_id: str,
+        storage_path: str,
+        local_file_path: Path | str,
+    ):
+        # TODO(ofey404): split upload for large file
+        LOGGER.debug(f"Uploading {local_file_path} to {storage_type.value}://{storage_id}/{storage_path}")
+        url = self._get_presigned_upload_urls(
+            storage_type=storage_type,
+            storage_id=storage_id,
+            file_path=storage_path,
+            total_parts=1,
+        )[0]
+
+        with open(local_file_path) as f:
+            content = f.read()
+            self._upload(url, content)
+
+    def _upload(
+        self,
+        presigned_url: str,
+        data: str,
+    ):
+        response = self.session.put(
+            presigned_url,
+            data,
+        )
+        response.close()
+        if response.status_code != 200:
+            raise ApiError(f"Upload failed with status code {response.status_code}, body: {response.text}")
+
+    def _get_presigned_upload_urls(
+        self,
+        storage_type: StorageType,
+        storage_id: str,
+        file_path: str,
+        total_parts,
+    ) -> List[str]:
+        url = str(self.config.api_server) + "/api/presignUpload"
+
+        if self.token == "":
+            raise LoginRequiredError()
+
+        headers = {
+            'Content-Type': 'application/json',
+            'Authorization': 'Bearer ' + self.token,
+        }
+        payload = json.dumps({
+            "type": storage_type.value,
+            "id": storage_id,
+            "filePath": file_path,
+            "totalParts": total_parts,
+        })
+
+        response = self.session.request(
+            "POST",
+            url,
+            headers=headers,
+            data=payload,
+        )
+
+        if response.status_code == 200:
+            return response.json()["presignedUrls"]
+        else:
+            raise ApiError(f"presignUpload failed with status code {response.status_code}, body: {response.text}")

--- a/colossalai_platform/cli/api/api.py
+++ b/colossalai_platform/cli/api/api.py
@@ -65,7 +65,7 @@ class ColossalPlatformApi:
         storage_path: str,
         local_file_path: Path | str,
     ):
-        # TODO(ofey404): split upload for large file
+        # TODO(ofey404): multi part upload for large file
         LOGGER.debug(f"Uploading {local_file_path} to {storage_type.value}://{storage_id}/{storage_path}")
         url = self._get_presigned_upload_urls(
             storage_type=storage_type,
@@ -88,6 +88,7 @@ class ColossalPlatformApi:
             data,
         )
         response.close()
+
         if response.status_code != 200:
             raise ApiError(f"Upload failed with status code {response.status_code}, body: {response.text}")
 

--- a/colossalai_platform/cli/cli.py
+++ b/colossalai_platform/cli/cli.py
@@ -3,8 +3,8 @@ import logging
 import click
 
 from colossalai_platform.cli.aliased_group import (CONTEXT_SETTINGS, AliasedGroup)
-from colossalai_platform.cli.context import BaseCommandContext
-from .api.api import LoginError
+from colossalai_platform.cli.context import CommandContext
+from .api import ApiError
 
 from .commands import project, dataset, configure
 
@@ -34,13 +34,13 @@ def cli(
     debug: bool,
 ):
     configure_logging(debug)
-    ctx.obj = BaseCommandContext()
+    ctx.obj = CommandContext()
 
     if ctx.invoked_subcommand in REQUIRE_LOGIN:
         # TODO(ofey404): persist token to file, rather than login every time
         try:
             ctx.obj.api.login()
-        except LoginError as e:
+        except ApiError as e:
             click.echo(e)
             ctx.exit(1)
 

--- a/colossalai_platform/cli/commands/__init__.py
+++ b/colossalai_platform/cli/commands/__init__.py
@@ -1,3 +1,3 @@
 from .project import project
-from .dataset import dataset
+from .dataset.dataset import dataset
 from .configure import configure

--- a/colossalai_platform/cli/commands/configure.py
+++ b/colossalai_platform/cli/commands/configure.py
@@ -1,8 +1,8 @@
 import click
 
 from colossalai_platform.cli.aliased_group import (CONTEXT_SETTINGS, AliasedGroup)
-from colossalai_platform.cli.api.api import LoginError
-from colossalai_platform.cli.context import BaseCommandContext
+from colossalai_platform.cli.api import ApiError
+from colossalai_platform.cli.context import CommandContext
 
 LOGIN_URL = "https://luchentech.com/api/user/login"
 
@@ -13,16 +13,16 @@ def configure(ctx: click.Context):
     # TODO(ofey404): In first version we build interactive login,
     #                and save username/password to local dir.
 
-    base_ctx = ctx.find_object(BaseCommandContext)
-    assert base_ctx
+    cmd_ctx = ctx.find_object(CommandContext)
+    assert cmd_ctx
 
-    base_ctx.config.username = click.prompt("Username")
-    base_ctx.config.password = click.prompt("Password (Hide input)", hide_input=True)
+    cmd_ctx.config.username = click.prompt("Username")
+    cmd_ctx.config.password = click.prompt("Password (Hide input)", hide_input=True)
 
     try:
-        ctx.obj.api.login()
-    except LoginError as e:
+        cmd_ctx.api.login()
+    except ApiError as e:
         click.echo(e)
         ctx.exit(1)
 
-    base_ctx.dump_to_dir()
+    cmd_ctx.dump_to_dir()

--- a/colossalai_platform/cli/commands/dataset/__init__.py
+++ b/colossalai_platform/cli/commands/dataset/__init__.py
@@ -1,0 +1,3 @@
+from .dataset import dataset
+
+__all__ = ["dataset"]

--- a/colossalai_platform/cli/commands/dataset/dataset.py
+++ b/colossalai_platform/cli/commands/dataset/dataset.py
@@ -1,12 +1,13 @@
-import os
-import shutil
-
 import click
 
-from colossalai_platform.cli.aliased_group import (CONTEXT_SETTINGS, AliasedGroup)
+from colossalai_platform.cli.aliased_group import AliasedGroup, CONTEXT_SETTINGS
+from colossalai_platform.cli.commands.dataset.upload_dir import upload_dir
 
 
 @click.command(cls=AliasedGroup, context_settings=CONTEXT_SETTINGS, help="Manage your datasets")
 def dataset():
     """TODO(ofey404): build this after login feature"""
     pass
+
+
+dataset.add_command(upload_dir)

--- a/colossalai_platform/cli/commands/dataset/dataset.py
+++ b/colossalai_platform/cli/commands/dataset/dataset.py
@@ -6,7 +6,6 @@ from colossalai_platform.cli.commands.dataset.upload_dir import upload_dir
 
 @click.command(cls=AliasedGroup, context_settings=CONTEXT_SETTINGS, help="Manage your datasets")
 def dataset():
-    """TODO(ofey404): build this after login feature"""
     pass
 
 

--- a/colossalai_platform/cli/commands/dataset/upload_dir.py
+++ b/colossalai_platform/cli/commands/dataset/upload_dir.py
@@ -1,0 +1,51 @@
+import logging
+
+import click
+import pathlib
+from typing import Iterable
+
+from colossalai_platform.cli.api import StorageType
+from colossalai_platform.cli.context import CommandContext
+
+LOGGER = logging.getLogger(__name__)
+
+
+@click.command(help="Upload the whole directory as a dataset")
+@click.argument('dataset_id', required=1, type=str)
+@click.argument('directory', required=1, type=pathlib.Path)
+@click.pass_context
+def upload_dir(
+    ctx: click.Context,
+    dataset_id: str,
+    directory: pathlib.Path,
+):
+    cmd_ctx = ctx.find_object(CommandContext)
+    assert cmd_ctx
+
+    click.echo(f"Uploading directory {directory} as dataset {dataset_id}...")
+    for local_file_path in _get_all_local_file_path(directory):
+        storage_path = _relative_posix_path(directory, local_file_path)
+        click.echo(f"{local_file_path} => {storage_path}")
+
+        LOGGER.debug(
+            f"local_file_path: {local_file_path}, storage_path: {storage_path}, local_file_path: {local_file_path}")
+        cmd_ctx.api.upload(
+            storage_type=StorageType.DATASET,
+            storage_id=dataset_id,
+            storage_path=storage_path,
+            local_file_path=local_file_path,
+        )
+    click.echo("Done")
+
+
+def _get_all_local_file_path(directory) -> Iterable[pathlib.Path]:
+    directory = pathlib.Path(directory)
+    return (p for p in directory.glob("**/*") if p.is_file())
+
+
+def _relative_posix_path(
+    directory: pathlib.Path,
+    local_file_path: pathlib.Path,
+):
+    assert directory in local_file_path.parents
+    return local_file_path.relative_to(directory).as_posix()

--- a/colossalai_platform/cli/commands/dataset/upload_dir.py
+++ b/colossalai_platform/cli/commands/dataset/upload_dir.py
@@ -23,18 +23,19 @@ def upload_dir(
     assert cmd_ctx
 
     click.echo(f"Uploading directory {directory} as dataset {dataset_id}...")
+
     for local_file_path in _get_all_local_file_path(directory):
         storage_path = _relative_posix_path(directory, local_file_path)
+
         click.echo(f"{local_file_path} => {storage_path}")
 
-        LOGGER.debug(
-            f"local_file_path: {local_file_path}, storage_path: {storage_path}, local_file_path: {local_file_path}")
         cmd_ctx.api.upload(
             storage_type=StorageType.DATASET,
             storage_id=dataset_id,
             storage_path=storage_path,
             local_file_path=local_file_path,
         )
+
     click.echo("Done")
 
 

--- a/colossalai_platform/cli/config.py
+++ b/colossalai_platform/cli/config.py
@@ -1,6 +1,7 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, HttpUrl
 
 
 class Config(BaseModel):
+    api_server: HttpUrl = "https://luchentech.com"
     username: str = ""
     password: str = ""

--- a/colossalai_platform/cli/context.py
+++ b/colossalai_platform/cli/context.py
@@ -15,10 +15,10 @@ LOGGER = logging.getLogger(__name__)
 
 @dataclass
 class BaseCommandContext:
-    """This `base` method is the only way to provide
-    dataclass-like initialization, while we can inject
-     code at `__init__` method
-     """
+    """This `base` class is the only way to persist
+    dataclass-like **kwargs initialization, while we can inject
+    code at CommandContext's `__init__` method
+    """
     dir: Path = Path.home() / ".colossalai-platform"
     config: Config = Config()
     api: ColossalPlatformApi = None

--- a/colossalai_platform/cli/context.py
+++ b/colossalai_platform/cli/context.py
@@ -4,6 +4,7 @@ import os
 from dataclasses import dataclass
 from pathlib import Path
 
+import click
 import yaml
 from pydantic import BaseModel
 
@@ -33,11 +34,10 @@ class CommandContext(BaseCommandContext):
         if self.config_path().is_file():
             self._load_config()
         else:
-            # TODO(ofey404): more formal logging
-            print(f"## Config doesn't exist on {self.config_path()}, writing default to it")
+            click.echo(f"Config doesn't exist on {self.config_path()}, writing default to it")
             self.dump_to_dir()
 
-        LOGGER.debug(f"## Config: {self.config}")
+        LOGGER.debug(f"Config: {self.config}")
 
         if self.api is None:
             self.api = ColossalPlatformApi(config=self.config)

--- a/colossalai_platform/cli/context.py
+++ b/colossalai_platform/cli/context.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+from dataclasses import dataclass
 from pathlib import Path
 
 import yaml
@@ -12,10 +13,18 @@ from colossalai_platform.cli.config import Config
 LOGGER = logging.getLogger(__name__)
 
 
-class BaseCommandContext(BaseModel):
+@dataclass
+class BaseCommandContext:
+    """This `base` method is the only way to provide
+    dataclass-like initialization, while we can inject
+     code at `__init__` method
+     """
     dir: Path = Path.home() / ".colossalai-platform"
     config: Config = Config()
     api: ColossalPlatformApi = None
+
+
+class CommandContext(BaseCommandContext):
 
     def __init__(self, **kwargs):
         # set up default value

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-click
-requests
-pydantic
-pyyaml
+requests>=2
+click~=8.1.6
+pydantic~=2.1.1
+pyyaml~=5.4.1


### PR DESCRIPTION
`cap dataset upload-dir` can: upload the whole directory as a dataset.

This PR only supports single-part uploading.

I plan to add multi-part uploading in a following PR.

## manual uploading test

This PR has no test. I'm thinking about mocking our API.

![image](https://github.com/hpcaitech/ColossalAI-Platform-CLI/assets/35857538/0293f40e-fd44-42c6-88bf-9deb4cac189e)
![image](https://github.com/hpcaitech/ColossalAI-Platform-CLI/assets/35857538/390a7890-ec4c-4f2e-a07d-855fca46d8c3)
