### PR TITLE
[devops] downgrade to `pyyaml~=5.3.1`

### DIFF
--- a/colossalai_platform/cli/api/__init__.py
+++ b/colossalai_platform/cli/api/__init__.py
@@ -1,5 +1,5 @@
 from .api import ColossalPlatformApi, StorageType, ApiError, LoginRequiredError, UploadRequest, DatasetNotFoundError, \
-    DatasetDeleteFilesRequest, NoObjectToDeleteError
+    DatasetDeleteFilesRequest, NoObjectToDeleteError, DatasetListResponse
 
 __all__ = [
     ColossalPlatformApi,
@@ -10,4 +10,5 @@ __all__ = [
     NoObjectToDeleteError,
     UploadRequest,
     DatasetDeleteFilesRequest,
+    DatasetListResponse,
 ]

--- a/colossalai_platform/cli/api/api.py
+++ b/colossalai_platform/cli/api/api.py
@@ -71,7 +71,7 @@ class ColossalPlatformApi:
     session: requests.Session = requests.Session()
 
     def login(self):
-        url = str(self.config.api_server) + "/api/user/login"
+        url = self.config.api_server + "/api/user/login"
 
         if self.config.username == "" or self.config.password == "":
             raise ApiError("Username or password is empty, please call `cap configure` first")
@@ -91,7 +91,7 @@ class ColossalPlatformApi:
             raise ApiError(f"{url} failed with status code {response.status_code}, body: {response.text}")
 
     def dataset_info(self, dataset_id: str) -> DatasetInfoResponse:
-        url = str(self.config.api_server) + "/api/dataset/info"
+        url = self.config.api_server + "/api/dataset/info"
 
         response = self.session.post(
             url,
@@ -110,7 +110,7 @@ class ColossalPlatformApi:
             raise ApiError(f"{url} failed with status code {response.status_code}, body: {response.text}")
 
     def dataset_delete_files(self, req: DatasetDeleteFilesRequest):
-        url = str(self.config.api_server) + "/api/dataset/file/delete"
+        url = self.config.api_server + "/api/dataset/file/delete"
 
         response = self.session.post(
             url,
@@ -177,7 +177,7 @@ class ColossalPlatformApi:
         if total_parts == 1:
           there is no `uploadId` in the response.
         """
-        url = str(self.config.api_server) + "/api/presignUpload"
+        url = self.config.api_server + "/api/presignUpload"
 
         response = self.session.post(
             url,
@@ -250,7 +250,7 @@ class ColossalPlatformApi:
         upload_id: str,
         etags: List[str],
     ):
-        url = str(self.config.api_server) + "/api/completeMultipartUpload"
+        url = self.config.api_server + "/api/completeMultipartUpload"
 
         response = self.session.post(
             url,

--- a/colossalai_platform/cli/commands/dataset/dataset.py
+++ b/colossalai_platform/cli/commands/dataset/dataset.py
@@ -1,6 +1,7 @@
 import click
 
 from colossalai_platform.cli.aliased_group import AliasedGroup, CONTEXT_SETTINGS
+from colossalai_platform.cli.commands.dataset.list import list_dataset
 from colossalai_platform.cli.commands.dataset.upload_dir import upload_dir
 
 
@@ -10,3 +11,4 @@ def dataset():
 
 
 dataset.add_command(upload_dir)
+dataset.add_command(list_dataset)

--- a/colossalai_platform/cli/commands/dataset/list.py
+++ b/colossalai_platform/cli/commands/dataset/list.py
@@ -1,0 +1,30 @@
+import click
+import textwrap
+
+from colossalai_platform.cli.api import DatasetListResponse
+from colossalai_platform.cli.context import CommandContext
+
+
+@click.command(name="list", help="list datasets")
+@click.pass_context
+def list_dataset(ctx: click.Context,):
+    cmd_ctx = ctx.find_object(CommandContext)
+    assert cmd_ctx
+
+    datasets = cmd_ctx.api.dataset_list()
+
+    for i, d in enumerate(datasets):
+        _pretty_print_dataset(d)
+
+
+def _pretty_print_dataset(
+    d: DatasetListResponse,
+    indent: int = 2,
+):
+    s = f"""Name: {d.datasetName}
+ID: {d.datasetId}
+Full Name: {d.datasetFullName}
+Description: {d.datasetDescription}
+Created At: {d.createdAt}
+"""
+    click.echo(textwrap.indent(s, " " * indent))

--- a/colossalai_platform/cli/config.py
+++ b/colossalai_platform/cli/config.py
@@ -2,7 +2,7 @@ from pydantic import BaseModel, HttpUrl
 
 
 class Config(BaseModel):
-    api_server: HttpUrl = "https://luchentech.com"
+    api_server: str = "https://luchentech.com"
     username: str = ""
     password: str = ""
     max_upload_chunk_bytes: int = 1024 * 1024 * 1024    # 1 GB

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,9 @@
 requests>=2
 click~=8.1.6
 pydantic~=2.1.1
-pyyaml~=5.4.1
+
+# Use PyYaml 5.3.1 until this issue is resolved:
+# https://github.com/yaml/pyyaml/issues/724
+#
+# Otherwise the pip install above python 3.10 would fail.
+pyyaml~=5.3.1


### PR DESCRIPTION
The 1pip install` would fail when python > 3.10.

![image](https://github.com/hpcaitech/ColossalAI-Platform-CLI/assets/35857538/95c27480-a735-4848-bac7-a138fbe58890)

This is a known issue of `pyyaml` library, more to see: https://github.com/yaml/pyyaml/issues/724

## `cap dataset list`

Also add a list command:

![image](https://github.com/hpcaitech/ColossalAI-Platform-CLI/assets/35857538/e0f11dbc-1d49-4e1d-846c-a01ff7d6f1de)
