### PR TITLE
[cli] fix: Updated API server configuration for production

### DIFF
--- a/colossalai_platform/cli/commands/configure.py
+++ b/colossalai_platform/cli/commands/configure.py
@@ -26,3 +26,15 @@ def configure(ctx: click.Context):
         ctx.exit(1)
 
     cmd_ctx.dump_to_dir()
+
+    click.echo("""Login successfully!
+
+Thank you for choosing the ColossalAI Platform!
+During our public beta phase, we're actively developing and improving the platform. We appreciate your patience with any user experience issues.
+
+For assistance, visit [doc link](TODO) or reach out anytime.
+Your feedback is valuable as we strive to enhance your experience.
+""")
+
+
+# TODO(ofey404): Add a link to the doc page containing `support contact`.

--- a/colossalai_platform/cli/config.py
+++ b/colossalai_platform/cli/config.py
@@ -2,7 +2,7 @@ from pydantic import BaseModel, HttpUrl
 
 
 class Config(BaseModel):
-    api_server: str = "https://luchentech.com"
+    api_server: str = "https://101.126.46.176"
     username: str = ""
     password: str = ""
     max_upload_chunk_bytes: int = 1024 * 1024 * 1024    # 1 GB


### PR DESCRIPTION
This PR is to make the default configuration file points to our production cluster.

Also, it adds a welcome comment when user calling `cap configure`:

![image](https://github.com/hpcaitech/ColossalAI-Platform-CLI/assets/35857538/a3d2ecc4-282c-4d41-a090-f7337900f663)
