### PR TITLE
[feature] `cap job submit`

### DIFF
--- a/colossalai_platform/cli/api/project.py
+++ b/colossalai_platform/cli/api/project.py
@@ -26,6 +26,7 @@ class ProjectInfoResponse:
     projectDescription: str
     createAt: str
     projectId: str
+    tags: List[str]
 
 @dataclass
 class HyperParametersResponse:

--- a/colossalai_platform/cli/commands/job/cli.py
+++ b/colossalai_platform/cli/commands/job/cli.py
@@ -3,6 +3,7 @@ import click
 from colossalai_platform.cli.aliased_group import AliasedGroup, CONTEXT_SETTINGS
 from colossalai_platform.cli.commands.job.init_yaml import init_yaml
 from colossalai_platform.cli.commands.job.list import list_job
+from colossalai_platform.cli.commands.job.submit import submit
 
 
 @click.command(cls=AliasedGroup, context_settings=CONTEXT_SETTINGS, help="Manage your jobs")
@@ -12,3 +13,4 @@ def job():
 
 job.add_command(list_job)
 job.add_command(init_yaml)
+job.add_command(submit)

--- a/colossalai_platform/cli/commands/job/init_yaml.py
+++ b/colossalai_platform/cli/commands/job/init_yaml.py
@@ -3,7 +3,7 @@ import sys
 
 import click
 
-from colossalai_platform.cli.commands.job.init_yaml.jobyaml import new_job_yaml, MountType
+from colossalai_platform.cli.commands.job.internal.jobyaml import new_job_yaml, MountType
 from colossalai_platform.cli.context import CommandContext
 
 @click.command(name="init-yaml", help="init job yaml")
@@ -37,6 +37,7 @@ def init_yaml(
     hyperparameters = cmd_ctx.api.project().hyperparameters(project_id, version)
     images = cmd_ctx.api.job().images()
     gpus = cmd_ctx.api.resource().gpus()
+    project_info = cmd_ctx.api.project().info(project_id)
 
     job_yaml = new_job_yaml(
         project_id,
@@ -49,13 +50,14 @@ def init_yaml(
             id=project_id,
             version=version,
             mountPath="/mnt/project",
-            name="my-project",
+            name=project_info.projectName,
             readOnly=True
         )
     )
     if stdout:
         job_yaml.dump_str_with_comment(sys.stdout)
-        return
+        ctx.exit(0)  # return
+
     with open(output_path, 'wt') as f:
         job_yaml.dump_str_with_comment(f)
         print(f"Job yaml is written to {output_path}")

--- a/colossalai_platform/cli/commands/job/init_yaml/__init__.py
+++ b/colossalai_platform/cli/commands/job/init_yaml/__init__.py
@@ -1,5 +1,0 @@
-from .init_yaml import init_yaml
-
-__all__ = [
-    "init_yaml",
-]

--- a/colossalai_platform/cli/commands/job/internal/jobyaml.py
+++ b/colossalai_platform/cli/commands/job/internal/jobyaml.py
@@ -43,7 +43,7 @@ class JobYaml(ModelWithYamlComment):
     resourceType: str = "public"
     resourceType_comment_eol_: str = "Options: [public, private]"
 
-    gpu: Gpu = Field(default_factory=lambda: Gpu(gpuType="NVIDIA-V100", manufacturer="Nvidia", number=1))
+    gpu: Gpu = None
     gpu_comment_after_: str = ""
 
     mounts: List[MountType] = []
@@ -130,6 +130,7 @@ run `cap dataset list`, `cap project list`, or `cap model list`.
             for h in hyperparameters
         },
         hyperParameters_comment_after_=hyperparameters_comment,
+        gpus=Gpu(gpuType=gpus[0].gpuType, manufacturer=gpus[0].manufacturer, number=gpus[0].availableCounts[0]),
         gpu_comment_after_=gpu_comment,
         mounts_comment_after_=mounts_comment,
         mounts=[project_mount]

--- a/colossalai_platform/cli/commands/job/internal/jobyaml.py
+++ b/colossalai_platform/cli/commands/job/internal/jobyaml.py
@@ -1,9 +1,11 @@
+import json
 from datetime import datetime
 from typing import List, Dict, Any
 
 from pydantic import Field
 
-from colossalai_platform.cli.api.job import ImagesResponse
+from colossalai_platform.cli.api import job
+from colossalai_platform.cli.api.job import ImagesResponse, JobCreateRequest
 from colossalai_platform.cli.api.project import HyperParametersResponse
 from colossalai_platform.cli.api.resource import GpusResponse
 from colossalai_platform.cli.utils.pydantic_model_with_yaml_comment import ModelWithYamlComment
@@ -26,28 +28,50 @@ class Gpu(ModelWithYamlComment):
 
 
 class JobYaml(ModelWithYamlComment):
-    jobName: str
+    jobName: str = "from-project-{xx}"
     jobName_comment_eol_: str = "change to your job name"
 
-    jobDescription: str
+    jobDescription: str = "from project {xx}"
     jobDescription_comment_eol_: str = "change to your job description"
 
     image: str = "change/to/your/image:latest"
-    image_comment_before_: str
+    image_comment_before_: str = ""
 
     hyperParameters: Dict[str, str] = Field(default_factory=dict)
-    hyperParameters_comment_after_: str
+    hyperParameters_comment_after_: str = ""
 
     resourceType: str = "public"
     resourceType_comment_eol_: str = "Options: [public, private]"
 
     gpu: Gpu = Field(default_factory=lambda: Gpu(gpuType="NVIDIA-V100", manufacturer="Nvidia", number=1))
-    gpu_comment_after_: str
+    gpu_comment_after_: str = ""
 
-    mounts: List[MountType]
-    mounts_comment_after_: str
+    mounts: List[MountType] = []
+    mounts_comment_after_: str = ""
 
     launchCommand: str = "bash /mnt/project/train.sh"
+
+    def to_api_req(self) -> JobCreateRequest:
+        return JobCreateRequest(
+            jobName=self.jobName,
+            jobDescription=self.jobDescription,
+            launchCommand=self.launchCommand,
+            image=self.image,
+            poolType=self.resourceType,
+            gpuType=self.gpu.gpuType,
+            numberOfGpu=self.gpu.number,
+            manufacturer=self.gpu.manufacturer,
+            hyperParameters=json.dumps(self.hyperParameters),  # json string
+            mounts=[job.MountType(
+                type=m.type,
+                id=m.id,
+                version=m.version,
+                mountPath=m.mountPath,
+                name=m.name,
+                readOnly=m.readOnly
+            ) for m in self.mounts],
+        )
+
 
 def new_job_yaml(
         project_id: str,
@@ -70,8 +94,8 @@ image: nexus.platform.colossalai.com/base/colossal-ai:cuda11.8-torch2.1.0
 ############################
 # Example of this section: #
 ############################
-- strategy: ddp
-- model: opt
+strategy: ddp
+model: opt
 """
 
     gpu_comment = f"""Available GPU types:
@@ -101,10 +125,12 @@ run `cap dataset list`, `cap project list`, or `cap model list`.
         jobName=f"job-{generate_random_string(5)}-from-project-{project_id}-version-{version}",
         jobDescription=f"From project {project_id}, yaml created by cli at {datetime.now().strftime('%Y-%m-%d-%H:%M:%S')}",
         image_comment_before_=image_comment,
+        hyperParameters={
+            h.name: h.defaultValue
+            for h in hyperparameters
+        },
         hyperParameters_comment_after_=hyperparameters_comment,
         gpu_comment_after_=gpu_comment,
         mounts_comment_after_=mounts_comment,
         mounts=[project_mount]
     )
-
-

--- a/colossalai_platform/cli/commands/job/submit.py
+++ b/colossalai_platform/cli/commands/job/submit.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+
+import click
+import yaml
+
+from colossalai_platform.cli.api import ApiError
+from colossalai_platform.cli.commands.job.internal.jobyaml import JobYaml
+from colossalai_platform.cli.context import CommandContext
+
+
+@click.command(name="submit", help="submit job yaml")
+@click.argument('job_yaml', required=1, type=str)
+@click.pass_context
+def submit(
+        ctx: click.Context,
+        job_yaml: Path,
+):
+    cmd_ctx = ctx.find_object(CommandContext)
+    assert cmd_ctx
+
+    with open(job_yaml, 'r') as f:
+        job_yaml_dict = yaml.safe_load(f)
+
+    j = JobYaml().model_validate(job_yaml_dict)
+
+    try:
+        resp = cmd_ctx.api.job().create(j.to_api_req())
+        click.echo(f"Job ID {resp.jobId} has been submitted.")
+        click.echo(f"Visit {cmd_ctx.config.api_server}/console/job/detail/{resp.jobId}/info for more details.")
+
+    except ApiError as e:
+        click.echo(e)
+        ctx.exit(1)


### PR DESCRIPTION
This PR adds a `submit job` feature to the CLI.

Generate the job yaml with `cap job init-yaml`, edit it following the comment, then submit as follows:

![屏幕截图 2024-03-26 112815](https://github.com/hpcaitech/ColossalAI-Platform-CLI/assets/35857538/f5580604-dfe5-451b-8696-011ceb6cdb4b)

The created job:

![屏幕截图 2024-03-26 112736](https://github.com/hpcaitech/ColossalAI-Platform-CLI/assets/35857538/9991038a-cee0-458a-8f4c-3fb6400df287)
